### PR TITLE
Improve sorting options, add new trending sort

### DIFF
--- a/app/Livewire/GameList.php
+++ b/app/Livewire/GameList.php
@@ -35,6 +35,7 @@ class GameList extends Component
         'english_word_count' => 'Word Count',
         'rating_count' => 'Review Count',
         'name' => 'Name',
+        'trending' => 'Trending',
     ];
 
     public string $search = '';
@@ -243,7 +244,19 @@ class GameList extends Component
             ->leftJoin('version_language_stats as english_stats', function ($join) {
                 $join->on('latest_versions.id', '=', 'english_stats.game_version_id')
                     ->where('english_stats.iso_code', '=', 'eng');
-            });
+            })
+            ->leftJoinSub(
+                DB::table('click_stats')
+                    ->selectRaw('COUNT(*) as trending_score, game_id')
+                    ->where('type', 'page_view')
+                    ->where('clicked_at', '>=', DB::raw("NOW() - INTERVAL '14 days'"))
+                    ->groupBy('game_id'),
+                'trending',
+                function ($join) {
+                    $join->on('games.id', '=', 'trending.game_id');
+                }
+            )
+            ->addSelect(DB::raw('COALESCE(trending.trending_score, 0) as trending_score'));
 
         // Apply filters
         $query->when(! $this->showHidden, fn ($q) => $q->where('is_visible', true))
@@ -317,6 +330,7 @@ class GameList extends Component
         $column = match ($this->sortField) {
             'latest_version_published_at' => 'latest_versions.published_at',
             'english_word_count' => 'english_stats.words',
+            'trending' => 'trending_score',
             default => "games.{$this->sortField}"
         };
 

--- a/app/Livewire/GameList.php
+++ b/app/Livewire/GameList.php
@@ -9,6 +9,7 @@ use App\Models\GameJam;
 use App\Models\Language;
 use App\Models\Tag;
 use App\Models\VnList;
+use App\Traits\HasDefaultSort;
 use App\Traits\HasSocialMetaTags;
 use App\Traits\HasSortableColumns;
 use App\Traits\SortsVnLists;
@@ -23,7 +24,7 @@ use Livewire\WithPagination;
 
 class GameList extends Component
 {
-    use HasSocialMetaTags, HasSortableColumns, SortsVnLists, WithPagination;
+    use HasDefaultSort, HasSocialMetaTags, HasSortableColumns, SortsVnLists, WithPagination;
 
     private static array $filterOptions = [];
 
@@ -35,9 +36,6 @@ class GameList extends Component
         'rating_count' => 'Review Count',
         'name' => 'Name',
     ];
-
-    private const string DEFAULT_SORT_FIELD = 'first_visible_at';
-    private const string DEFAULT_SORT_DIRECTION = 'desc';
 
     public string $search = '';
 
@@ -194,8 +192,8 @@ class GameList extends Component
         // Dispatch an event to notify Alpine components that filters were cleared
         $this->dispatch('filtersCleared');
         $this->sfw = false;
-        $this->sortField = self::DEFAULT_SORT_FIELD;
-        $this->sortDirection = self::DEFAULT_SORT_DIRECTION;
+        $this->sortField = self::getDefaultSortField();
+        $this->sortDirection = self::getDefaultSortDirection();
         $this->showHidden = false;
         $this->resetPage();
     }
@@ -377,8 +375,8 @@ class GameList extends Component
 
     public function resetSort(): void
     {
-        $this->sortField = self::DEFAULT_SORT_FIELD;
-        $this->sortDirection = self::DEFAULT_SORT_DIRECTION;
+        $this->sortField = self::getDefaultSortField();
+        $this->sortDirection = self::getDefaultSortDirection();
         $this->resetPage();
     }
 

--- a/app/Livewire/GameList.php
+++ b/app/Livewire/GameList.php
@@ -28,13 +28,16 @@ class GameList extends Component
     private static array $filterOptions = [];
 
     protected const array AVAILABLE_SORT_FIELDS = [
+        'first_visible_at' => 'Recently Added',
         'latest_version_published_at' => 'Latest Update',
         'initially_published_at' => 'Initial Release',
-        'first_visible_at' => 'Recently Added',
         'english_word_count' => 'Word Count',
         'rating_count' => 'Review Count',
         'name' => 'Name',
     ];
+
+    private const string DEFAULT_SORT_FIELD = 'first_visible_at';
+    private const string DEFAULT_SORT_DIRECTION = 'desc';
 
     public string $search = '';
 
@@ -64,9 +67,9 @@ class GameList extends Component
 
     public bool $showHidden = false;
 
-    public string $sortField = 'latest_version_published_at';
+    public string $sortField = self::DEFAULT_SORT_FIELD;
 
-    public string $sortDirection = 'desc';
+    public string $sortDirection = self::DEFAULT_SORT_DIRECTION;
 
     public string|int $perPage = 9;
 
@@ -88,8 +91,8 @@ class GameList extends Component
         'showFree' => ['except' => false],
         'showDemo' => ['except' => false],
         'showSuspended' => ['except' => false],
-        'sortField' => ['except' => 'latest_version_published_at'],
-        'sortDirection' => ['except' => 'desc'],
+        'sortField' => ['except' => self::DEFAULT_SORT_FIELD],
+        'sortDirection' => ['except' => self::DEFAULT_SORT_DIRECTION],
         'perPage' => ['except' => 9],
         'page' => ['except' => 1],
         'showHidden' => ['except' => false],
@@ -191,8 +194,8 @@ class GameList extends Component
         // Dispatch an event to notify Alpine components that filters were cleared
         $this->dispatch('filtersCleared');
         $this->sfw = false;
-        $this->sortField = 'latest_version_published_at';
-        $this->sortDirection = 'desc';
+        $this->sortField = self::DEFAULT_SORT_FIELD;
+        $this->sortDirection = self::DEFAULT_SORT_DIRECTION;
         $this->showHidden = false;
         $this->resetPage();
     }
@@ -374,8 +377,8 @@ class GameList extends Component
 
     public function resetSort(): void
     {
-        $this->sortField = 'latest_version_published_at';
-        $this->sortDirection = 'desc';
+        $this->sortField = self::DEFAULT_SORT_FIELD;
+        $this->sortDirection = self::DEFAULT_SORT_DIRECTION;
         $this->resetPage();
     }
 

--- a/app/Traits/HasDefaultSort.php
+++ b/app/Traits/HasDefaultSort.php
@@ -6,8 +6,8 @@ namespace App\Traits;
 
 trait HasDefaultSort
 {
-    private const string DEFAULT_SORT_FIELD = 'first_visible_at';
-    private const string DEFAULT_SORT_DIRECTION = 'desc';
+    protected const string DEFAULT_SORT_FIELD = 'first_visible_at';
+    protected const string DEFAULT_SORT_DIRECTION = 'desc';
 
     public static function getDefaultSortField(): string
     {

--- a/app/Traits/HasDefaultSort.php
+++ b/app/Traits/HasDefaultSort.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+trait HasDefaultSort
+{
+    private const string DEFAULT_SORT_FIELD = 'first_visible_at';
+    private const string DEFAULT_SORT_DIRECTION = 'desc';
+
+    public static function getDefaultSortField(): string
+    {
+        return self::DEFAULT_SORT_FIELD;
+    }
+
+    public static function getDefaultSortDirection(): string
+    {
+        return self::DEFAULT_SORT_DIRECTION;
+    }
+
+    public static function isDefaultSort(string $sortField, string $sortDirection): bool
+    {
+        return $sortField === self::DEFAULT_SORT_FIELD && $sortDirection === self::DEFAULT_SORT_DIRECTION;
+    }
+} 

--- a/app/Traits/HasSocialMetaTags.php
+++ b/app/Traits/HasSocialMetaTags.php
@@ -6,10 +6,12 @@ namespace App\Traits;
 
 use App\Livewire\RaterDetail;
 use App\Models\Language;
+use App\Traits\HasDefaultSort;
 use Illuminate\Support\Str;
 
 trait HasSocialMetaTags
 {
+    use HasDefaultSort;
     protected function getMetaTitle(): string
     {
         $title = '';
@@ -149,7 +151,7 @@ trait HasSocialMetaTags
 
             // Add sort information if not default
             if (property_exists($this, 'sortField') &&
-                ($this->sortField !== 'latest_version_published_at' || $this->sortDirection !== 'desc')) {
+                !$this->isDefaultSort($this->sortField, $this->sortDirection)) {
                 $sortLabels = $this::AVAILABLE_SORT_FIELDS;
 
                 $description .= ", sorted by {$sortLabels[$this->sortField]} " .

--- a/app/Traits/HasSortableColumns.php
+++ b/app/Traits/HasSortableColumns.php
@@ -26,6 +26,7 @@ trait HasSortableColumns
             'rating' => 'Rating',
             'rating_count' => 'Review Count',
             'name' => 'Name',
+            'trending' => 'Trending',
             default => ucfirst(str_replace('_', ' ', $field))
         };
     }

--- a/resources/views/games/list/partials/active-filters.blade.php
+++ b/resources/views/games/list/partials/active-filters.blade.php
@@ -1,4 +1,4 @@
-@if (!empty($selectedPlatforms) || !empty($selectedStatuses) || !empty($selectedEngines) || !empty($selectedLanguages) || !empty($selectedGameJams) || !empty($selectedTags) || $nsfw || $sfw || $showPaid || $showFree || $showDemo || $showSuspended || ($sortField !== 'latest_version_published_at' || $sortDirection !== 'desc') || $showHidden)
+@if (!empty($selectedPlatforms) || !empty($selectedStatuses) || !empty($selectedEngines) || !empty($selectedLanguages) || !empty($selectedGameJams) || !empty($selectedTags) || $nsfw || $sfw || $showPaid || $showFree || $showDemo || $showSuspended || ($sortField !== 'first_visible_at' || $sortDirection !== 'desc') || $showHidden)
     <div class="mb-4">
         <div class="flex items-center justify-between">
             <div class="text-sm font-medium text-gray-900 dark:text-gray-300">Active Filters:</div>

--- a/resources/views/games/list/partials/active-filters.blade.php
+++ b/resources/views/games/list/partials/active-filters.blade.php
@@ -1,4 +1,4 @@
-@if (!empty($selectedPlatforms) || !empty($selectedStatuses) || !empty($selectedEngines) || !empty($selectedLanguages) || !empty($selectedGameJams) || !empty($selectedTags) || $nsfw || $sfw || $showPaid || $showFree || $showDemo || $showSuspended || ($sortField !== 'first_visible_at' || $sortDirection !== 'desc') || $showHidden)
+@if (!empty($selectedPlatforms) || !empty($selectedStatuses) || !empty($selectedEngines) || !empty($selectedLanguages) || !empty($selectedGameJams) || !empty($selectedTags) || $nsfw || $sfw || $showPaid || $showFree || $showDemo || $showSuspended || !$this->isDefaultSort($sortField, $sortDirection) || $showHidden)
     <div class="mb-4">
         <div class="flex items-center justify-between">
             <div class="text-sm font-medium text-gray-900 dark:text-gray-300">Active Filters:</div>

--- a/resources/views/games/list/partials/search-controls.blade.php
+++ b/resources/views/games/list/partials/search-controls.blade.php
@@ -12,7 +12,7 @@
             'sort' => [
                 'icon' => 'heroicon-o-arrows-up-down',
                 'modal' => 'sort-modal',
-                'active' => $sortField !== 'latest_version_published_at' || $sortDirection !== 'desc'
+                'active' => $sortField !== 'first_visible_at' || $sortDirection !== 'desc'
             ],
             'filters' => [
                 'icon' => 'heroicon-o-funnel',

--- a/resources/views/games/list/partials/search-controls.blade.php
+++ b/resources/views/games/list/partials/search-controls.blade.php
@@ -12,7 +12,7 @@
             'sort' => [
                 'icon' => 'heroicon-o-arrows-up-down',
                 'modal' => 'sort-modal',
-                'active' => $sortField !== 'first_visible_at' || $sortDirection !== 'desc'
+                'active' => !$this->isDefaultSort($sortField, $sortDirection)
             ],
             'filters' => [
                 'icon' => 'heroicon-o-funnel',

--- a/resources/views/games/list/partials/sort-indicator.blade.php
+++ b/resources/views/games/list/partials/sort-indicator.blade.php
@@ -1,5 +1,5 @@
 @php
-    $isDefaultSort = $sortField === 'latest_version_published_at' && $sortDirection === 'desc';
+    $isDefaultSort = $this->isDefaultSort($sortField, $sortDirection);
 @endphp
 @if (!$isDefaultSort)
     <button

--- a/tests/Unit/HasDefaultSortTraitTest.php
+++ b/tests/Unit/HasDefaultSortTraitTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Traits\HasDefaultSort;
+use PHPUnit\Framework\TestCase;
+
+class HasDefaultSortTraitTest extends TestCase
+{
+    use HasDefaultSort;
+
+    public function test_get_default_sort_field(): void
+    {
+        $this->assertEquals('first_visible_at', self::getDefaultSortField());
+    }
+
+    public function test_get_default_sort_direction(): void
+    {
+        $this->assertEquals('desc', self::getDefaultSortDirection());
+    }
+
+    public function test_is_default_sort(): void
+    {
+        $this->assertTrue(self::isDefaultSort('first_visible_at', 'desc'));
+        $this->assertFalse(self::isDefaultSort('first_visible_at', 'asc'));
+        $this->assertFalse(self::isDefaultSort('name', 'desc'));
+        $this->assertFalse(self::isDefaultSort('name', 'asc'));
+    }
+} 


### PR DESCRIPTION
# Overview

This PR updates the default sorting and adds a new Trending order.

See #116 

# Implementation Details

 - The default sorting order was changed from Latest Update (latest_version_published_at) to Recently Added (first_visible_at)
 - A new trait was added as the source of truth for the default sort
 - A new **Trending** sort was added that uses a simple total of clicks over past 14 days.

No migrations were added, as the `click_stats` table already had an appropriate index.
```
"click_stats_game_id_type_clicked_at_index" btree (game_id, type, clicked_at)
```

# Testing

Very basic unit tests were added for the new trait.